### PR TITLE
#3 Add option to control animation trigger after pre render in blazor components

### DIFF
--- a/BlazeFX/BlazeFX.cs
+++ b/BlazeFX/BlazeFX.cs
@@ -5,14 +5,40 @@ using Microsoft.JSInterop;
 
 namespace BlazeFX;
 
+/// <inheritdoc />
 public class BlazeFX : ComponentBase
 {
     [Parameter] public RenderFragment ChildContent { get; set; }
-    [Parameter] public Animations Animation { get; set; }
-    [Parameter] public TimeSpan Duration { get; set; } = TimeSpan.FromSeconds(1);
-    [Parameter] public TimeSpan Delay { get; set; } = TimeSpan.Zero;
-    [Parameter] public Easing Easing { get; set; } = Easing.EaseIn;
-    [Parameter] public bool RenderCompleteOnly { get; set; } = false;
+
+    /// <summary>
+    /// The type of animation to apply.
+    /// </summary>
+    [Parameter]
+    public Animations Animation { get; set; }
+
+    /// <summary>
+    /// The duration of the animation.
+    /// </summary>
+    [Parameter]
+    public TimeSpan Duration { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The delay before the animation starts.
+    /// </summary>
+    [Parameter]
+    public TimeSpan Delay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// The easing function that controls the animation's acceleration.
+    /// </summary>
+    [Parameter]
+    public Easing Easing { get; set; } = Easing.EaseIn;
+
+    /// <summary>
+    /// If true, the animation will only render when complete.
+    /// </summary>
+    [Parameter]
+    public bool RenderCompleteOnly { get; set; } = false;
 
     [Inject] private IJSRuntime JSRuntime { get; set; }
 
@@ -20,6 +46,7 @@ public class BlazeFX : ComponentBase
     private bool _shouldAnimate = false;
     private string _currentStyle;
 
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
         if (RenderCompleteOnly)
@@ -33,6 +60,7 @@ public class BlazeFX : ComponentBase
         }
     }
 
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender && RenderCompleteOnly)
@@ -59,6 +87,7 @@ public class BlazeFX : ComponentBase
         await JSRuntime.InvokeVoidAsync("blazeFX.applyAnimation", _elementReference, classAttribute, _currentStyle);
     }
 
+    /// <inheritdoc />
     protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");

--- a/BlazeFX/BlazeFX.cs
+++ b/BlazeFX/BlazeFX.cs
@@ -36,6 +36,7 @@ public class BlazeFX : ComponentBase
 
     /// <summary>
     /// If true, the animation will only render when complete.
+    /// IMPORTANT! If RenderCompleteOnly is set to true but pre-rendering is not enabled (e.g., in a static server environment), the animation and the component involved may not appear, remaining visibly hidden.
     /// </summary>
     [Parameter]
     public bool RenderCompleteOnly { get; set; } = false;

--- a/BlazeFX/BlazeFX.cs
+++ b/BlazeFX/BlazeFX.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.JSInterop;
 
 namespace BlazeFX;
 
@@ -11,21 +12,76 @@ public class BlazeFX : ComponentBase
     [Parameter] public TimeSpan Duration { get; set; } = TimeSpan.FromSeconds(1);
     [Parameter] public TimeSpan Delay { get; set; } = TimeSpan.Zero;
     [Parameter] public Easing Easing { get; set; } = Easing.EaseIn;
+    [Parameter] public bool RenderCompleteOnly { get; set; } = false;
 
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    [Inject] private IJSRuntime JSRuntime { get; set; }
+
+    private ElementReference _elementReference;
+    private bool _shouldAnimate = false;
+    private string _currentStyle;
+
+    protected override void OnParametersSet()
+    {
+        if (RenderCompleteOnly)
+        {
+            _currentStyle = "visibility: hidden;";
+            _shouldAnimate = false;
+        }
+        else
+        {
+            SetAnimationStyle();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && RenderCompleteOnly)
+        {
+            SetAnimationStyle();
+            StateHasChanged();
+        }
+
+        if (_shouldAnimate)
+        {
+            await ApplyAnimationAsync();
+        }
+    }
+
+    private void SetAnimationStyle()
+    {
+        _currentStyle = GetAnimationStyle();
+        _shouldAnimate = true;
+    }
+
+    private async Task ApplyAnimationAsync()
+    {
+        var classAttribute = GetClassAttribute();
+        await JSRuntime.InvokeVoidAsync("blazeFX.applyAnimation", _elementReference, classAttribute, _currentStyle);
+    }
+
+    protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
-        builder.AddAttribute(1, "class", $"blazefx-animation {Animation.ToString().ToLowerInvariant()}");
-        builder.AddAttribute(2, "style", GetAnimationStyle());
-        builder.AddContent(3, ChildContent);
+        builder.AddAttribute(1, "class", GetClassAttribute());
+        builder.AddAttribute(2, "style", _currentStyle);
+        builder.AddElementReferenceCapture(3, elementReference => _elementReference = elementReference);
+        builder.AddContent(4, ChildContent);
         builder.CloseElement();
+    }
+
+    private string GetClassAttribute()
+    {
+        const string baseClass = "blazefx-animation";
+        var animationClass = Animation.ToString().ToLowerInvariant();
+        return _shouldAnimate ? $"{baseClass} {animationClass}" : baseClass;
     }
 
     private string GetAnimationStyle()
     {
         return $"animation-duration: {Duration.TotalSeconds}s; " +
                $"animation-delay: {Delay.TotalSeconds}s; " +
-               $"animation-timing-function: {GetEasingFunction()};";
+               $"animation-timing-function: {GetEasingFunction()}; " +
+               $"visibility: visible;";
     }
 
     private string GetEasingFunction()
@@ -61,20 +117,6 @@ public class BlazeFX : ComponentBase
             Easing.EaseInBack => "cubic-bezier(0.36, 0, 0.66, -0.56)",
             Easing.EaseOutBack => "cubic-bezier(0.34, 1.56, 0.64, 1)",
             Easing.EaseInOutBack => "cubic-bezier(0.68, -0.6, 0.32, 1.6)",
-
-            // Soon ->
-
-            // Easing.StepStart => "step-start",
-            // Easing.StepEnd => "step-end",
-            //
-            // Easing.EaseInElastic => "ease-in-elastic",
-            // Easing.EaseOutElastic => "ease-out-elastic",
-            // Easing.EaseInOutElastic => "ease-in-out-elastic",
-            //
-            // Easing.EaseInBounce => "ease-in-bounce",
-            // Easing.EaseOutBounce => "ease-out-bounce",
-            // Easing.EaseInOutBounce => "ease-in-out-bounce",
-
             _ => "ease" // default
         };
     }

--- a/BlazeFX/BlazeFX.csproj
+++ b/BlazeFX/BlazeFX.csproj
@@ -16,12 +16,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<_ContentIncludedByDefault Remove="wwwroot\blazefx.css"/>
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.10"/>
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10"/>
+	</ItemGroup>
+
+	<!--Preserve this-->
+	<ItemGroup>
+		<Content Update="wwwroot\blazefx.js">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<!--Preserve this-->
+	<ItemGroup>
+		<_ContentIncludedByDefault Remove="wwwroot\blazefx.css"/>
 	</ItemGroup>
 
 </Project>

--- a/BlazeFX/BlazeFX.csproj
+++ b/BlazeFX/BlazeFX.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<PackageId>BlazeFX</PackageId>
-		<Version>1.1.1</Version>
+		<Version>1.1.2</Version>
 		<Authors>Matheus Evangelista Dos Santos</Authors>
 		<Description>BlazeFX is a animation library that provides simple CSS-based animations for Blazor components</Description>
 		<PackageTags>blazor;animation;css</PackageTags>

--- a/BlazeFX/Easing.cs
+++ b/BlazeFX/Easing.cs
@@ -7,8 +7,6 @@ public enum Easing
     EaseOut,
     EaseInOut,
     Linear,
-    // StepStart,
-    // StepEnd,
     EaseInSine,
     EaseOutSine,
     EaseInOutSine,
@@ -33,10 +31,4 @@ public enum Easing
     EaseInBack,
     EaseOutBack,
     EaseInOutBack,
-    // EaseInElastic,
-    // EaseOutElastic,
-    // EaseInOutElastic,
-    // EaseInBounce,
-    // EaseOutBounce,
-    // EaseInOutBounce
 }

--- a/BlazeFX/wwwroot/blazefx.js
+++ b/BlazeFX/wwwroot/blazefx.js
@@ -1,0 +1,8 @@
+window.blazeFX = {
+    applyAnimation: function (element, classAttribute, styleAttribute) {
+        if (element) {
+            element.className = classAttribute;
+            element.style.cssText = styleAttribute;
+        }
+    }
+};

--- a/README.md
+++ b/README.md
@@ -27,15 +27,21 @@ dotnet add package BlazeFX
     @using BlazeFX
     ```
 
-2. Include the required stylesheet in your HTML `<head>` section:
+2. Include the required stylesheet and script in your HTML:
 
-    - For Blazor WebAssembly, add the following to `index.html`:
+   - Stylesheet: Add the following to your HTML <head> section
 
     ```html
     <link rel="stylesheet" href="/_content/BlazeFX/blazefx.min.css" />
     ```
+   
+   - Script: Add the following script at the end of the <body> tag:
+   ```html
+    <script src="/_content/BlazeFX/blazefx.js"></script>
+    ```
 
-   For Blazor Server, add it to `_Layout.cshtml`, `_Host.cshtml`, or `App.razor`, depending on your project setup.
+   For Blazor WebAssembly, modify `index.html`.
+   For Blazor Server, modify `_Layout.cshtml`, `_Host.cshtml`, or `App.razor`, depending on your project setup.
 
 ## Usage
 
@@ -66,6 +72,8 @@ You can easily switch between various animations and adjust parameters like `Eas
 - `Easing`: Select an easing function to control the animation's progression
 - `Duration`: Set the length of the animation
 - `Delay`: Add a delay before the animation starts
+- `RenderCompleteOnly`: Ensure the animation runs only after pre-rendering is complete.
+
 
 ## Contributing
 
@@ -92,4 +100,9 @@ If you need help or have any questions, please:
 
 #### Double Animation on First Load
 
-If you encounter issues where animations run twice when your Blazor project/component is loaded for the first time, you may need to disable pre-rendering.
+If animations run twice when your Blazor project/component loads for the first time, use the `RenderCompleteOnly="true"` parameter to ensure the animation runs only after pre-rendering is complete.
+````razor
+<BlazeFX RenderCompleteOnly="true" Animation="Animations.Blinking" Easing="Easing.EaseInOut">
+    <h1>Hello, Animated World!</h1>
+</BlazeFX>
+````

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can easily switch between various animations and adjust parameters like `Eas
 - `Delay`: Add a delay before the animation starts
 - `RenderCompleteOnly`: Ensure the animation runs only after pre-rendering is complete.
 
+**IMPORTANT!** If RenderCompleteOnly is set to true but pre-rendering is not enabled (e.g., in a static server environment), the animation and the component involved may not appear, remaining visibly hidden.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request includes significant updates to the `BlazeFX` library, focusing on enhancing animation control, improving documentation, and updating dependencies. The most important changes include the introduction of a new `RenderCompleteOnly` parameter, addition of JavaScript interop for applying animations, and updates to the project file and documentation.

Enhancements to animation control:

* [`BlazeFX/BlazeFX.cs`](diffhunk://#diff-19bb291538f91733022691e1401f89c295b20707f732c881856701ae3a411f8fR2-R114): Introduced the `RenderCompleteOnly` parameter to ensure animations run only after pre-rendering is complete. Added JavaScript interop to apply animations dynamically.
* [`BlazeFX/wwwroot/blazefx.js`](diffhunk://#diff-6960308aa0c12dfb2a1072089a527c5e75ffa8333ab8dd3a28bf31065d113b17R1-R8): Added a new JavaScript function `applyAnimation` to handle the application of animation styles and classes.

Project file and dependency updates:

* [`BlazeFX/BlazeFX.csproj`](diffhunk://#diff-9b55254cb330bcb3df9bf8ef7c2f73f06f9d4506dec681b6f4e6586772513224L6-R6): Updated the version to `1.1.2` and added package references for `Microsoft.AspNetCore.Components` and `Microsoft.AspNetCore.Components.Web`. [[1]](diffhunk://#diff-9b55254cb330bcb3df9bf8ef7c2f73f06f9d4506dec681b6f4e6586772513224L6-R6) [[2]](diffhunk://#diff-9b55254cb330bcb3df9bf8ef7c2f73f06f9d4506dec681b6f4e6586772513224L19-R32)

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R44): Updated instructions to include the new `RenderCompleteOnly` parameter and added guidance on including the required script file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R77) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R109)

Code cleanup:

* [`BlazeFX/Easing.cs`](diffhunk://#diff-3439e516723097db1ecf3f58afe0d0000c7427307c556f918ffebdf1e9c9a578L10-L11): Removed commented-out easing functions to clean up the code. [[1]](diffhunk://#diff-3439e516723097db1ecf3f58afe0d0000c7427307c556f918ffebdf1e9c9a578L10-L11) [[2]](diffhunk://#diff-3439e516723097db1ecf3f58afe0d0000c7427307c556f918ffebdf1e9c9a578L36-L41)

These changes collectively enhance the functionality and usability of the `BlazeFX` library, providing better control over animations and clearer documentation for users.