### PR TITLE
Add support for dotnet 6 and 7

### DIFF
--- a/BlazeFX/BlazeFX.csproj
+++ b/BlazeFX/BlazeFX.csproj
@@ -1,35 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<PackageId>BlazeFX</PackageId>
-		<Version>1.1.3</Version>
-		<Authors>Matheus Evangelista Dos Santos</Authors>
-		<Description>BlazeFX is a animation library that provides simple CSS-based animations for Blazor components</Description>
-		<PackageTags>blazor;animation;css</PackageTags>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/mtevangelista7/BlazeFX</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/mtevangelista7/BlazeFX</RepositoryUrl>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<RepositoryType>GIT</RepositoryType>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <PackageId>BlazeFX</PackageId>
+        <Version>1.1.3</Version>
+        <Authors>Matheus Evangelista Dos Santos</Authors>
+        <Description>BlazeFX is a animation library that provides simple CSS-based animations for Blazor components</Description>
+        <PackageTags>blazor;animation;css</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/mtevangelista7/BlazeFX</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/mtevangelista7/BlazeFX</RepositoryUrl>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <RepositoryType>GIT</RepositoryType>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10"/>
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'"/>
 
-	<!--Preserve this-->
-	<ItemGroup>
-		<Content Update="wwwroot\blazefx.js">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'"/>
 
-	<!--Preserve this-->
-	<ItemGroup>
-		<_ContentIncludedByDefault Remove="wwwroot\blazefx.css"/>
-	</ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'"/>
+    </ItemGroup>
+
+    <!--Preserve this-->
+    <ItemGroup>
+        <Content Update="wwwroot\blazefx.js">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <!--Preserve this-->
+    <ItemGroup>
+        <_ContentIncludedByDefault Remove="wwwroot\blazefx.css"/>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the `BlazeFX` project to support multiple .NET target frameworks and adjusts package references accordingly.

Support for multiple .NET target frameworks:

* [`BlazeFX/BlazeFX.csproj`](diffhunk://#diff-9b55254cb330bcb3df9bf8ef7c2f73f06f9d4506dec681b6f4e6586772513224L4-R4): Changed from targeting `net8.0` to targeting `net6.0`, `net7.0`, and `net8.0`.

Package reference adjustments:

* [`BlazeFX/BlazeFX.csproj`](diffhunk://#diff-9b55254cb330bcb3df9bf8ef7c2f73f06f9d4506dec681b6f4e6586772513224L19-R26): Updated `Microsoft.AspNetCore.Components` and `Microsoft.AspNetCore.Components.Web` package references to conditionally match the respective target frameworks (`net6.0`, `net7.0`, `net8.0`).